### PR TITLE
fix for displaying elev. gain of segment on elev. info bar

### DIFF
--- a/src/components/ElevationInfoBar.tsx
+++ b/src/components/ElevationInfoBar.tsx
@@ -21,7 +21,7 @@ const ElevationInfoBar: React.FC<Props> = ({ cursorX, cursorDist, cursorElev, cu
       )}
       {cursorX && <span>|</span>}
       <div className="elevation-seg-data">
-        <span>{t.chartAvgGrade}: {segment ? segment.avgSlope.toFixed(1) : '-'}%</span> | <span>{t.chartLength}: {segment?.length ? (segment.length / 1000).toFixed(2) : '-'} km</span> | <span>{t.chartGain}: {segment ? segment.elevationGain > 0.5 ? segment.elevationGain.toFixed(0) : -segment.elevationLoss.toFixed(0) : '-'} m</span>
+        <span>{t.chartAvgGrade}: {segment ? segment.avgSlope.toFixed(1) : '-'}%</span> | <span>{t.chartLength}: {segment?.length ? (segment.length / 1000).toFixed(2) : '-'} km</span> | <span>{t.chartGain}: {segment ? (segment.elevationGain - segment.elevationLoss).toFixed(0) : '-'} m</span>
       </div>
     </div>
   );


### PR DESCRIPTION
The current implementation didn't take into account the possibility of having uphill and downhill parts in one segment,
so i make it to simply add this two together, another approach will be to display both of them but i feel that there will be too much of data even now its feel so crowded